### PR TITLE
added user friendly error message

### DIFF
--- a/sealighter/sealighter_controller.cpp
+++ b/sealighter/sealighter_controller.cpp
@@ -136,7 +136,7 @@ void add_filter_to_vector_property_compare
 
 
 /*
-    Add a single "property is" filter to a list. 
+    Add a single "property is" filter to a list.
 */
 void add_filter_to_vector_property_is_item
 (
@@ -393,7 +393,7 @@ int add_filters_to_vector
         log_messageA("failed to add filters from config to provider\n");
         log_messageA("%s\n", e.what());
         status = SEALIGHTER_ERROR_PARSE_FILTER;
-    }    
+    }
     return status;
 }
 
@@ -412,7 +412,7 @@ int add_filters
     int status = ERROR_SUCCESS;
 
     if (json_provider["filters"].is_null() ||
-        (json_provider["filters"]["any_of"].is_null() && 
+        (json_provider["filters"]["any_of"].is_null() &&
          json_provider["filters"]["all_of"].is_null() &&
          json_provider["filters"]["none_of"].is_null()
         )
@@ -664,7 +664,14 @@ int add_user_traces
                 pNew_provider = new provider<>(provider_guid);
             }
             else {
-                pNew_provider = new provider<>(provider_name);
+                try {
+                    pNew_provider = new provider<>(provider_name);
+                }
+                catch (const std::exception & e) {
+                    log_messageA("%s\n", e.what());
+                    status = SEALIGHTER_ERROR_NO_PROVIDER;
+                    break;
+                }
             }
             log_messageW(L"User Provider: %s\n", provider_name.c_str());
             log_messageA("    Trace Name: %s\n", trace_name.c_str());
@@ -882,6 +889,11 @@ void run_trace(trace<T>* trace)
         // Ensure we always stop the trace afterwards
         try {
             trace->start();
+        }
+        catch (const std::exception & e) {
+            log_messageA("%s\n", e.what());
+            trace->stop();
+            throw;
         }
         catch (...) {
             trace->stop();

--- a/sealighter/sealighter_errors.h
+++ b/sealighter/sealighter_errors.h
@@ -36,3 +36,6 @@
 
 // Counld't open output stream to output file
 #define SEALIGHTER_ERROR_OUTPUT_FILE 13
+
+// Failed to resolve the specified provider
+#define SEALIGHTER_ERROR_NO_PROVIDER 14


### PR DESCRIPTION
This change adds error message printing on at least 2 failure cases:
- when required privilege is not held to start the process 
- when the specified provider name is incorrect (ie, could not be resolved)

Here are examples of them:
```
>sealighter.exe Microsoft-Windows-Threat-Intelligence.json
Session Name: Sealighter-Trace
Outputs: stdout
User Provider: Microsoft-Windows-Threat-Intelligence
    Trace Name: ProcTrace02
    Keywords: All
    No event filters
Starting User Trace...
-----------------------------------------
Need to be an admin
```
```
>sealighter.exe "Microsoft.Windows.FooBar.json"
Session Name: Sealighter-Trace
Outputs: stdout
Provider name does not exist. (Microsoft.Windows.FooBar), hr = 0x0
```  

`Need to be an admin` and `Provider name does not exist. ` are effect of this patch. Currently, those error results in a process crash without any error messages.